### PR TITLE
change  "jmikola/auto-login" dependency to "1.0.*"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 
     "require" : {
         "php"                : ">=5.3.3",
-        "jmikola/auto-login" : "dev-master",
+        "jmikola/auto-login" : "1.0.*",
         "symfony/security"   : "~2.2"
     },
 


### PR DESCRIPTION
composer.json currently requires "jmikola/auto-login": "dev-master"

but

"jmikola/auto-login-bundle" requires "jmikola/auto-login": "1.0.*"

so composer cannot install both without this change
