### PR TITLE
substitute base64url_encode and base64url_decode functions for base64…

### DIFF
--- a/lib/Vandpibe/AutoLogin/Generator.php
+++ b/lib/Vandpibe/AutoLogin/Generator.php
@@ -45,14 +45,14 @@ class Generator implements GeneratorInterface
 
         $parameters['hash'] = $this->hasher->hash($parameters);
 
-        return self::base64url_encode(http_build_query($parameters));
+        return self::base64UrlEncode(http_build_query($parameters));
     }
 
-    public static function base64url_encode($data) {
+    public static function base64UrlEncode($data) {
         return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
     }
 
-    public static function base64url_decode($data) {
+    public static function base64UrlDecode($data) {
         return base64_decode(str_pad(strtr($data, '-_', '+/'), strlen($data) % 4, '=', STR_PAD_RIGHT));
     }
 }

--- a/lib/Vandpibe/AutoLogin/Generator.php
+++ b/lib/Vandpibe/AutoLogin/Generator.php
@@ -45,6 +45,14 @@ class Generator implements GeneratorInterface
 
         $parameters['hash'] = $this->hasher->hash($parameters);
 
-        return base64_encode(http_build_query($parameters));
+        return self::base64url_encode(http_build_query($parameters));
+    }
+
+    public static function base64url_encode($data) {
+        return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+    }
+
+    public static function base64url_decode($data) {
+        return base64_decode(str_pad(strtr($data, '-_', '+/'), strlen($data) % 4, '=', STR_PAD_RIGHT));
     }
 }

--- a/lib/Vandpibe/AutoLogin/Security/UserProvider.php
+++ b/lib/Vandpibe/AutoLogin/Security/UserProvider.php
@@ -15,6 +15,7 @@ use Jmikola\AutoLogin\Exception\AutoLoginTokenNotFoundException;
 use Jmikola\AutoLogin\User\AutoLoginUserProviderInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Vandpibe\AutoLogin\Generator;
 use Vandpibe\AutoLogin\HasherInterface;
 
 /**
@@ -66,7 +67,8 @@ class UserProvider implements AutoLoginUserProviderInterface, UserProviderInterf
         $username = null;
 
         // Parse the query string
-        parse_str(base64_decode($key));
+        parse_str(Generator::base64url_decode($key));
+//        parse_str(str_pad(strtr($key, '-_', '+/'), strlen($key) % 4, '=', STR_PAD_RIGHT));
 
         if (time() < $expireAt && $hash == $this->hasher->hash(compact('username', 'expireAt'))) {
             return $this->loadUserByUsername($username);

--- a/lib/Vandpibe/AutoLogin/Security/UserProvider.php
+++ b/lib/Vandpibe/AutoLogin/Security/UserProvider.php
@@ -67,7 +67,7 @@ class UserProvider implements AutoLoginUserProviderInterface, UserProviderInterf
         $username = null;
 
         // Parse the query string
-        parse_str(Generator::base64url_decode($key));
+        parse_str(Generator::base64UrlDecode($key));
 //        parse_str(str_pad(strtr($key, '-_', '+/'), strlen($key) % 4, '=', STR_PAD_RIGHT));
 
         if (time() < $expireAt && $hash == $this->hasher->hash(compact('username', 'expireAt'))) {

--- a/tests/Vandpibe/Test/AutoLogin/GeneratorTest.php
+++ b/tests/Vandpibe/Test/AutoLogin/GeneratorTest.php
@@ -41,7 +41,7 @@ class GeneratorTest extends \PHPUnit_Framework_TestCase
 
         $query = $this->generator->generate($this->user);
 
-        parse_str(Generator::base64url_decode($query));
+        parse_str(Generator::base64UrlDecode($query));
 
         $this->assertEquals('rikkipige', $username);
         $this->assertEquals('rikke-likes-hash', $hash);

--- a/tests/Vandpibe/Test/AutoLogin/GeneratorTest.php
+++ b/tests/Vandpibe/Test/AutoLogin/GeneratorTest.php
@@ -41,7 +41,7 @@ class GeneratorTest extends \PHPUnit_Framework_TestCase
 
         $query = $this->generator->generate($this->user);
 
-        parse_str(base64_decode($query));
+        parse_str(Generator::base64url_decode($query));
 
         $this->assertEquals('rikkipige', $username);
         $this->assertEquals('rikke-likes-hash', $hash);

--- a/tests/Vandpibe/Test/AutoLogin/Security/UserProviderTest.php
+++ b/tests/Vandpibe/Test/AutoLogin/Security/UserProviderTest.php
@@ -30,7 +30,8 @@ class UserProviderTest extends \PHPUnit_Framework_TestCase
 
     public function testThrowsExceptionWithInvalidHash()
     {
-        $this->setExpectedException('Jmikola\AutoLogin\Exception\AutoLoginTokenNotFoundException', '"$key" contains invalid information.');
+        $this->setExpectedException('Jmikola\AutoLogin\Exception\AutoLoginTokenNotFoundException',
+            '"$key" contains invalid information.');
 
         $this->hasher
             ->expects($this->once())
@@ -38,13 +39,15 @@ class UserProviderTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue('evenmoreinvalid'))
         ;
 
-        $this->provider->loadUserByAutoLoginToken(Generator::base64url_encode('username=henrik&expireAt=' . self::VALID_EXPIRE_AT . '&hash=invalid'));
+        $this->provider->loadUserByAutoLoginToken(Generator::base64UrlEncode('username=henrik&expireAt=' .
+            self::VALID_EXPIRE_AT . '&hash=invalid'));
     }
 
     public function testDontCallUserProviderWhenExpireAtIsInvalid()
     {
 
-        $this->setExpectedException('Jmikola\AutoLogin\Exception\AutoLoginTokenNotFoundException', '"$key" contains invalid information.');
+        $this->setExpectedException('Jmikola\AutoLogin\Exception\AutoLoginTokenNotFoundException',
+            '"$key" contains invalid information.');
 
         $this->hasher
             ->expects($this->never())
@@ -56,7 +59,7 @@ class UserProviderTest extends \PHPUnit_Framework_TestCase
             ->method('loadUserByUsername')
         ;
 
-        $this->provider->loadUserByAutoLoginToken(Generator::base64url_encode('username=henrik&expireAt=0&hash=invalid'));
+        $this->provider->loadUserByAutoLoginToken(Generator::base64UrlEncode('username=henrik&expireAt=0&hash=invalid'));
     }
 
     public function testCallUserProviderWhenHashIsValid()
@@ -74,6 +77,7 @@ class UserProviderTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('henrik'))
         ;
 
-        $this->provider->loadUserByAutoLoginToken(Generator::base64url_encode('username=henrik&expireAt=' . self::VALID_EXPIRE_AT . '&hash=valid'));
+        $this->provider->loadUserByAutoLoginToken(Generator::base64UrlEncode('username=henrik&expireAt=' .
+            self::VALID_EXPIRE_AT . '&hash=valid'));
     }
 }

--- a/tests/Vandpibe/Test/AutoLogin/Security/UserProviderTest.php
+++ b/tests/Vandpibe/Test/AutoLogin/Security/UserProviderTest.php
@@ -11,6 +11,7 @@
 
 namespace Vandpibe\Test\AutoLogin\Security;
 
+use Vandpibe\AutoLogin\Generator;
 use Vandpibe\AutoLogin\Security\UserProvider;
 
 /**
@@ -37,7 +38,7 @@ class UserProviderTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue('evenmoreinvalid'))
         ;
 
-        $this->provider->loadUserByAutoLoginToken(base64_encode('username=henrik&expireAt=' . self::VALID_EXPIRE_AT . '&hash=invalid'));
+        $this->provider->loadUserByAutoLoginToken(Generator::base64url_encode('username=henrik&expireAt=' . self::VALID_EXPIRE_AT . '&hash=invalid'));
     }
 
     public function testDontCallUserProviderWhenExpireAtIsInvalid()
@@ -55,7 +56,7 @@ class UserProviderTest extends \PHPUnit_Framework_TestCase
             ->method('loadUserByUsername')
         ;
 
-        $this->provider->loadUserByAutoLoginToken(base64_encode('username=henrik&expireAt=0&hash=invalid'));
+        $this->provider->loadUserByAutoLoginToken(Generator::base64url_encode('username=henrik&expireAt=0&hash=invalid'));
     }
 
     public function testCallUserProviderWhenHashIsValid()
@@ -73,6 +74,6 @@ class UserProviderTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('henrik'))
         ;
 
-        $this->provider->loadUserByAutoLoginToken(base64_encode('username=henrik&expireAt=' . self::VALID_EXPIRE_AT . '&hash=valid'));
+        $this->provider->loadUserByAutoLoginToken(Generator::base64url_encode('username=henrik&expireAt=' . self::VALID_EXPIRE_AT . '&hash=valid'));
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,4 @@
 <?php
 
-$autoload = require __DIR__ . '/../composer/autoload.php';
+$autoload = require __DIR__ . '/../vendor/autoload.php';
 $autoload->register('Vandpibe\Test\AutoLogin', __DIR__);


### PR DESCRIPTION
…_encode and base64_decode throughout

I have read that it is inappropriate or risky to use base64encode to create a query string. For example:

http://stackoverflow.com/questions/1374753/passing-base64-encoded-strings-in-url

http://stackoverflow.com/questions/11206259/issue-with-base64-encoded-parameter-in-query-string

One of the notes to the php manual page for base64_encode proposes url safe substitute functions base64url_encode and base64url_decode. In this pull request I have added those to Generate.php as static functions and substituted calls to them for calls to base64_encode and base64_decode throughout.

All phpunit tests pass. 

Since composer now places its autoload.php in the vendor folder, I have modified tests/Vandpibe/bootstrap.php accordingly.
